### PR TITLE
submodules: update mkosi

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,9 +27,5 @@ jobs:
           chmod 0600 mkosi.key
       - name: Bootstrap
         run:  ./scripts/bootstrap
-      # We have to build systemd first due to a regression introduced in
-      # https://github.com/systemd/mkosi/commit/14e70bf5edf196b3e9b02d1148f54b5f0350417f
-      - name: Build systemd
-        run:  ./mkosi -t none
       - name: Build
         run:  ./mkosi -f

--- a/README.md
+++ b/README.md
@@ -4,10 +4,9 @@ ArcadeOS is an appliance-style OS for arcade cabinets based on
 [ParticleOS](https://github.com/systemd/particleos).
 
 The ArcadeOS image is built using [mkosi](https://github.com/systemd/mkosi). To
-build the image, run `./mkosi -f` from the ArcadeOS repository. If mkosi
-complains about missing systemd host binaries or wrong versions, run
-`./mkosi -t none` first to build a freestanding version from our submodule.
-It's also recommended to set a root password (e.g. via `mkosi.rootpw` or
+build the image, run `./mkosi -f` from the ArcadeOS repository.
+
+It's recommended to set a root password (e.g. via `mkosi.rootpw` or
 `RootPassword=` in `mkosi.local.conf`), as otherwise `systemd-firstboot` will
 prompt for one on startup, but the prompt won't be visible due to the boot
 splash unless that's dismissed.


### PR DESCRIPTION
Also remove the workaround introduced in https://github.com/davide125/arcadeos/commit/fe04dc1878d6e9a7461c27fd42dc346f4fa59111 as it's no longer needed after https://github.com/systemd/mkosi/commit/b1632384f7885f061bfcd5f9bd14ebafd1256cb5